### PR TITLE
feat: Add Helm chart for production-grade SpiceDB cluster by salekseev

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ _Tools that help enhance the experience of using SpiceDB_
 
 - [spicedb-operator-libsonnet](https://github.com/jsonnet-libs/spicedb-operator-libsonnet) - Jsonnet library for the SpiceDB Operator
 - [bushelpowered/spicedb-operator-chart](https://github.com/bushelpowered/spicedb-operator-chart) - Helm chart to install the SpiceDB Operator
+- [salekseev/helm-charts](https://github.com/salekseev/helm-charts/tree/master/charts/spicedb) - Helm chart to install production-grade SpiceDB cluster
 - [mleonidas/tree-sitter-authzed](https://github.com/mleonidas/tree-sitter-authzed) - Neovim tree-sitter grammar and syntax for SpiceDB schemas
 - [nhedger/vscode-spicedb](https://github.com/nhedger/vscode-spicedb) - Third-party VSCode extension
 - [chiperific/vscode_authzed_syntax](https://github.com/chiperific/vscode_authzed_syntax) - Third-party VSCode syntax highlighting


### PR DESCRIPTION
This pull request adds a new tool to the list of resources for enhancing the SpiceDB experience in the `README.md` file. The addition is a Helm chart for installing a production-grade SpiceDB cluster if operator cannot be used.

Enhancements to SpiceDB tooling documentation:

* Added `[salekseev/helm-charts](https://github.com/salekseev/helm-charts/tree/master/charts/spicedb)` as a recommended Helm chart for installing a production-grade SpiceDB cluster in the `_Tools that help enhance the experience of using SpiceDB_` section of the `README.md`.